### PR TITLE
Add Names type to allow selecting elements by excluding others

### DIFF
--- a/src/NamedArray.jl
+++ b/src/NamedArray.jl
@@ -93,6 +93,18 @@ function indices(dict::Dict, I::IndexOrNamed)
     elseif isa(I, String)
         dI = dict[I]
         return dI:dI
+    elseif isa(I, Names)
+        k = keys(dict)
+
+        if !is(eltype(I.names), eltype(k))
+            error("Elements of the Names object must be of the same type as the array names for each dimension")
+        end
+
+        if(I.exclude)
+            return map(function(s) dict[s] end, setdiff(k, I.names))
+        else
+            return map(function(s) dict[s] end, I.names)
+        end
     elseif isa(I, AbstractVector)
         if eltype(I) <: String
             return map(function(s) dict[s] end, I)
@@ -116,7 +128,6 @@ function getindex(A::NamedArray, I::IndexOrNamed...)
     names = map(function(i) getindex(A.names[i],II[i]) end, 1:length(II))
     NamedArray{eltype(a),ndims(a)}(a, vec2tuple(names...), vec2tuple(A.dimnames...))
 end
-
 
 ## These seem to be caught by the general getindex, I'm not sure if this is what we want...
 getindex(A::NamedArray, i0::Real) = arrayref(A.array,to_index(i0))

--- a/src/namedarraytypes.jl
+++ b/src/namedarraytypes.jl
@@ -49,8 +49,22 @@ function NamedArray(a::Array)
     dimnames = [string(char(64+i)) for i=1:ndims(a)]
     NamedArray(a, vec2tuple(names...), vec2tuple(dimnames...))
 end
-    
+
+
+immutable Names
+    names::Vector
+    exclude::Bool
+end
+
+function Names(names::Vector)
+    Names(names, false)
+end
+
+function !(names::Names)
+    Names(names.names, !names.exclude)
+end
+
 
 typealias NamedVector{T} NamedArray{T,1}
 typealias ArrayOrNamed{T} Union(Array{T}, NamedArray{T})
-typealias IndexOrNamed Union(Real, Range1, String, AbstractVector)
+typealias IndexOrNamed Union(Real, Range1, String, Names, AbstractVector)


### PR DESCRIPTION
Here's a first stab at the kind of convenience syntax I spoke about on the mailing list. Comments welcome.

This allows things like:

``` julia
julia> reload("src/NamedArray.jl")
        n = NamedArray(rand(2,4))
       setnames!(n, ["one", "two"], 1)       
["one"=>1,"two"=>2]

julia> n[!Names(["one"]), Names(["1"])]
NamedArray{Float64,2}
names: two
1
dimnames: A B

.14859425443510443
```

To save more typing, the type could be renamed to e.g. N.
