### PR TITLE
Added constructors, with tests, that leave out dimnames argument.

### DIFF
--- a/src/constructors.jl
+++ b/src/constructors.jl
@@ -11,11 +11,25 @@ function NamedArray{T,N}(a::AbstractArray{T,N}, names::NTuple{N,Associative}, di
     NamedArray{T, N, typeof(a), typeof(names)}(a, names, dimnames) ## inner constructor
 end
 
+## dimnames created as default, then inner constructor called
+function NamedArray{T,N}(array::AbstractArray{T,N}, names::NTuple{N,Associative})
+    dimnames = [symbol(string(char(64+i))) for i=1:ndims(array)]
+    NamedArray{T, N, typeof(array), typeof(names)}(array, names, tuple(dimnames...)) ## inner constructor
+end
+
 ## constructor with array, names and dimnames (dict is created from names)
 function NamedArray{T,N}(array::AbstractArray{T,N}, names::NTuple{N,Vector}, dimnames::NTuple{N})
     dicts = map(names -> Dict(zip(names,1:length(names))), names)
-    NamedArray(array, dicts, dimnames) # call constructor above
+    NamedArray(array, dicts, dimnames)
 end
+
+## constructor with array, names (dict is created from names), dimnames created as default
+function NamedArray{T,N}(array::AbstractArray{T,N}, names::NTuple{N,Vector})
+    dicts = map(names -> Dict(zip(names,1:length(names))), names)
+    dimnames = [symbol(string(char(64+i))) for i=1:length(names)]
+    NamedArray(array, dicts, tuple(dimnames...))
+end
+
 
 ## Type and dimensions
 function NamedArray(T::DataType, dims::Int...)

--- a/test/test.jl
+++ b/test/test.jl
@@ -10,6 +10,15 @@ n = NamedArray(rand(2,4))
 setnames!(n, ["one", "two"], 1) 
 setnames!(n, ["a", "b", "c", "d"], 2) 
 
+a = [1 2 3; 4 5 6]
+n3 = NamedArray(a, (["a","b"],["C","D","E"]))
+n4 = NamedArray(a, (["a"=>1,"b"=>2],["C"=>1,"D"=>2,"E"=>3]))
+
+@assert n3.array == n4.array == a
+@assert dimnames(n3) == dimnames(n4) == Any[:A,:B]
+@assert names(n3,1) == names(n4,1) == ["a","b"]
+@assert names(n3,2) == names(n4,2) == ["C","D","E"]
+
 print("getindex, ")
 ## getindex
 @assert [x for x in n] == [x for x in n.array]


### PR DESCRIPTION
Would you be open to having some constructors for NamedArrays that leave out the dimnames argument? I have proposed two that take the array and either the vector of names or the names Dicts.