### PR TITLE
DO NOT MERGE: rely on julia-0.5 indexing mechanisms to fix a segfault

### DIFF
--- a/test/test.jl
+++ b/test/test.jl
@@ -244,4 +244,8 @@ t2 = @elapsed sgetindex(n.array)
 si, sj = allnames(n)
 t3 = @elapsed sgetindex(n, si, sj)
 
+# julia issue #17328
+a = NamedArray([1.0,2.0,3.0,4.0])
+@test sumabs(a, 1)[1] == 10
+
 println("Timing named index:", t1, " array index:", t2, " named key:", t3)


### PR DESCRIPTION
This fixes https://github.com/JuliaLang/julia/issues/17328, and is one of those happy circumstances where deleting a lot of code makes things work better. By declaring that the number of indices must match the dimensionality of the array, you're now allowing some of the automatic fallback mechanisms to kick in. In particular, trying to index `a[i,j]` when `a` is 1-dimensional should just check that `j==1` (or is a `CartesianIndex{0}` or similar) and then return `a[i]`. By restricting dispatch to the case where the number of indices matches the dimensionality, you can let this happen.

The reason this is marked DO NOT MERGE is that it works only on julia-0.5, and I haven't tested the impact this has on performance (probably favorable due to those `@inline` statements). On earlier versions of julia, you could annotate all those methods for the specific dimensionality, but I think the "splatting" version is basically unfixable :frowning: unless you write the bounds-checking code yourself (which wouldn't be so bad, e.g., `map(i->@assert(i==1), I[ndims(a)-5:end])` or something, except you might need to handle `1:1`, `[1]`, `CartesianIndex` types, etc.).

CC @tkelman.