### PR TITLE
Switch to OrderedDict for names

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,4 @@
 julia 0.4
 Compat
 Combinatorics
+DataStructures 0.4.4

--- a/src/NamedArrays.jl
+++ b/src/NamedArrays.jl
@@ -11,6 +11,7 @@ VERSION >= v"0.4.0-dev+6521" && __precompile__()
 module NamedArrays
 
 using Compat
+using DataStructures
 
 export NamedArray, NamedVector, NamedMatrix, Not
 

--- a/src/changingnames.jl
+++ b/src/changingnames.jl
@@ -11,7 +11,7 @@ for f = (:sum, :prod, :maximum, :minimum, :mean, :std, :var)
     eval(Expr(:import, :Base, f))
     @eval function ($f)(a::NamedArray, d::Dims)
         s = ($f)(a.array, d)
-        dicts = [issubset(i,d) ? Dict(string($f,"(",a.dimnames[i],")") => 1) : a.dicts[i] for i=1:ndims(a)]
+        dicts = [issubset(i,d) ? OrderedDict(string($f,"(",a.dimnames[i],")") => 1) : a.dicts[i] for i=1:ndims(a)]
         NamedArray(s, tuple(dicts...), a.dimnames)
     end
     @eval ($f)(a::NamedArray, d::Int) = ($f)(a, (d,))

--- a/src/constructors.jl
+++ b/src/constructors.jl
@@ -16,25 +16,25 @@ end
 
 ## Basic constructor: array, tuple of dicts, tuple
 ## This calls the inner constructor with the appropriate types
-function NamedArray{T,N}(a::AbstractArray{T,N}, names::NTuple{N,Associative}, dimnames::NTuple{N})
+function NamedArray{T,N}(a::AbstractArray{T,N}, names::NTuple{N,OrderedDict}, dimnames::NTuple{N})
     NamedArray{T, N, typeof(a), typeof(names)}(a, names, dimnames) ## inner constructor
 end
 
 ## dimnames created as default, then inner constructor called
-function NamedArray{T,N}(array::AbstractArray{T,N}, names::NTuple{N,Associative})
+function NamedArray{T,N}(array::AbstractArray{T,N}, names::NTuple{N,OrderedDict})
     dimnames = [Symbol(letter(i)) for i=1:ndims(array)]
     NamedArray{T, N, typeof(array), typeof(names)}(array, names, tuple(dimnames...)) ## inner constructor
 end
 
 ## constructor with array, names and dimnames (dict is created from names)
 function NamedArray{T,N}(array::AbstractArray{T,N}, names::NTuple{N,Vector}, dimnames::NTuple{N})
-    dicts = map(names -> Dict(zip(names,1:length(names))), names)
+    dicts = map(names -> OrderedDict(zip(names,1:length(names))), names)
     NamedArray(array, dicts, dimnames)
 end
 
 ## constructor with array, names (dict is created from names), dimnames created as default
 function NamedArray{T,N}(array::AbstractArray{T,N}, names::NTuple{N,Vector})
-    dicts = map(names -> Dict(zip(names,1:length(names))), names)
+    dicts = map(names -> OrderedDict(zip(names,1:length(names))), names)
     dimnames = [Symbol(letter(i)) for i=1:length(names)]
     NamedArray(array, dicts, tuple(dimnames...))
 end
@@ -44,10 +44,10 @@ function NamedArray{T,N,VT}(a::AbstractArray{T,N},
                             names::Vector{VT}=[String[string(i) for i=1:d] for d in size(a)],
                             dimnames::Vector = Symbol[Symbol(letter(i)) for i=1:N])
     length(names) == length(dimnames) == N || error("Dimension mismatch")
-    if VT <: Associative
+    if VT <: OrderedDict
         dicts = tuple(names...)
     else
-        dicts = map(names -> Dict(zip(names,1:length(names))), tuple(names...))
+        dicts = map(names -> OrderedDict(zip(names,1:length(names))), tuple(names...))
     end
     NamedArray(a, dicts, tuple(dimnames...))
 end

--- a/src/keepnames.jl
+++ b/src/keepnames.jl
@@ -68,11 +68,10 @@ end
 import Base: sort, sort!
 function sort!(a::NamedVector; kws...)
     i = sortperm(a.array; kws...)
-    newi = similar(i)
-    newi[i] = 1:size(a,1)
-    n = names(a, 1)
-    for (key, index) in zip(n, newi)
-        a.dicts[1][key] = index
+    newnames = names(a, 1)[i]
+    empty!(a.dicts[1])
+    for (ind, k) in enumerate(newnames)
+        a.dicts[1][k] = ind
     end
     a.array = a.array[i]
     a

--- a/src/namedarraytypes.jl
+++ b/src/namedarraytypes.jl
@@ -15,7 +15,7 @@ type NamedArray{T,N,AT,DT} <: AbstractArray{T,N}
     array::AT
     dicts::DT
     dimnames::NTuple{N}
-    function NamedArray(array::AbstractArray{T,N}, dicts::NTuple{N,Associative}, dimnames::NTuple{N})
+    function NamedArray(array::AbstractArray{T,N}, dicts::NTuple{N,OrderedDict}, dimnames::NTuple{N})
         size(array) == map(length, dicts) || error("Inconsistent dictionary sizes")
 #        for (d,dict) in zip(size(array),dicts)
 #            Set(values(dict)) == Set(1:d) || error("Inconsistent values in dict")

--- a/src/names.jl
+++ b/src/names.jl
@@ -25,10 +25,10 @@ function setnames!(a::NamedArray, v::Vector, d::Int)
     size(a.array,d) == length(v) || error("inconsistent vector length")
     eltype(keys(a.dicts[d])) == eltype(v) || error("inconsistent name type")
     ## a.dicts is a tuple, so we need to replace it as a whole...
-    vdicts = Dict[]
+    vdicts = OrderedDict[]
     for i = 1:length(a.dicts)
         if i==d
-            push!(vdicts, Dict(zip(v, 1:length(v))))
+            push!(vdicts, OrderedDict(zip(v, 1:length(v))))
         else
             push!(vdicts, a.dicts[i])
         end

--- a/src/names.jl
+++ b/src/names.jl
@@ -6,14 +6,14 @@
 
 import Base.names
 
-sortnames(dict::Associative) = collect(keys(dict))[sortperm(collect(values(dict)))] 
-allnames(a::NamedArray) = [sortnames(dict) for dict in a.dicts]
-names(a::NamedArray, d::Int) = sortnames(a.dicts[d])
+names(dict::Associative) = collect(keys(dict))
+allnames(a::NamedArray) = [names(dict) for dict in a.dicts]
+names(a::NamedArray, d::Int) = names(a.dicts[d])
 dimnames(a::NamedArray) = [dn for dn in a.dimnames]
 dimnames(a::NamedArray, d::Int) = a.dimnames[d]
 
 ## string versions of the above
-strnames(dict::Associative) = map(string, sortnames(dict))
+strnames(dict::Associative) = map(string, names(dict))
 strnames(a::NamedArray) = [strnames(d) for d in a.dicts]
 strnames(a::NamedArray, d::Int) = strnames(a.dicts[d])
 strdimnames(a::NamedArray) = [string(dn) for dn in a.dimnames]

--- a/src/rearrange.jl
+++ b/src/rearrange.jl
@@ -18,13 +18,15 @@ end
 
 import Base.flipdim
 function flipdim{T,N}(a::NamedArray{T,N}, d::Int)
-    vdicts = Array(Dict, N)
+    vdicts = Array(OrderedDict, N)
     n = size(a,d)+1
     for i=1:N
         dict = copy(a.dicts[i])
         if i==d
-            for (k,v) in collect(dict)
-                dict[k] = n - v
+            newnames = reverse(names(dict))
+            empty!(dict)
+            for (ind,k) in enumerate(newnames)
+                dict[k] = ind
             end
         end
         vdicts[i] = dict

--- a/test/test.jl
+++ b/test/test.jl
@@ -1,5 +1,7 @@
 ## NamedArrays is loaded by runtests.jl
 using Base.Test
+using DataStructures
+using Compat
 
 print("Starting test, no assertions should fail... ")
 
@@ -13,7 +15,7 @@ setnames!(n, ["a", "b", "c", "d"], 2)
 
 a = [1 2 3; 4 5 6]
 n3 = NamedArray(a, (["a","b"],["C","D","E"]))
-n4 = NamedArray(a, (@compat Dict("a"=>1,"b"=>2),@compat Dict("C"=>1,"D"=>2,"E"=>3)))
+n4 = NamedArray(a, (@compat OrderedDict("a"=>1,"b"=>2), @compat OrderedDict("C"=>1,"D"=>2,"E"=>3)))
 
 @test n3.array == n4.array == a
 @test dimnames(n3) == dimnames(n4) == Any[:A,:B]

--- a/timings
+++ b/timings
@@ -1,0 +1,22 @@
+macro timeit(ex)
+# like @time, but returning the timing rather than the computed value
+  return quote
+    #gc_disable()
+    local val = $ex # compile
+    local t0 = time()
+    for i in 1:1e4 val = $ex end
+    local t1 = time()
+    #gc_enable()
+    t1-t0
+  end
+end
+
+n2 = NamedArray(rand(1000, 1000))
+
+# With master
+julia> @timeit n2[1:100, 1:100]
+2.445374011993408
+
+# With this PR
+julia> @timeit n2[1:100, 1:100]
+0.5610759258270264


### PR DESCRIPTION
This PR changes the names dicts to OrderedDict, which is good for about a 4X speedup for subsetting with a 1000 x 1000 matrix. The code is a bit simpler too.

```julia
using NamedArrays

macro timeit(ex)
# like @time, but returning the timing rather than the computed value
  return quote
    #gc_disable()
    local val = $ex # compile
    local t0 = time()
    for i in 1:1e4 val = $ex end
    local t1 = time()
    #gc_enable()
    t1-t0
  end
end

n2 = NamedArray(rand(1000, 1000))

# With master
julia> @timeit n2[1:100, 1:100]
2.445374011993408

# With this PR
julia> @timeit n2[1:100, 1:100]
0.5610759258270264
```