### PR TITLE
fix NamedVector head alignment when dimname is long

### DIFF
--- a/src/show.jl
+++ b/src/show.jl
@@ -160,7 +160,7 @@ function show(io::IO, v::NamedVector, maxnrow::Int)
     rowrange, totrowrange = compute_range(maxnrow, nrow)
     s = [sprint(showcompact, v.array[i]) for i=totrowrange]
     colwidth = maximum(map(length,s))
-    rownamewidth = maximum(map(length, rownames))
+    rownamewidth = max(maximum(map(length, rownames)), 1+length(strdimnames(v)[1]))
     ## header
     println(io, string(leftalign(strdimnames(v, 1), rownamewidth), " │ "))
     print(io, "─"^(rownamewidth+1), "┼", "─"^(colwidth+1))


### PR DESCRIPTION
Right now there is alignment issue if dim name is long, for example

```
ROWS │
──┼──
A │ 1
B │ 3
```

After this PR, head line will use same width as row names.