### PR TITLE
Use showcompact to print names

### DIFF
--- a/src/names.jl
+++ b/src/names.jl
@@ -23,7 +23,7 @@ dimnames(a::AbstractArray) = [defaultdimnames(a)...]
 dimnames(a::AbstractArray, d::Integer) = defaultdimname(d)
 
 ## string versions of the above
-strnames(dict::Associative) = map(string, names(dict))
+strnames(dict::Associative) = [isa(name, String) ? name : sprint(showcompact, name) for name in names(dict)]
 strnames(n::NamedArray) = [strnames(d) for d in n.dicts]
 strnames(n::NamedArray, d::Integer) = strnames(n.dicts[d])
 strdimnames(n::NamedArray) = [string(dn) for dn in n.dimnames]

--- a/test/show.jl
+++ b/test/show.jl
@@ -102,3 +102,16 @@ lines = showlines(NamedArray(sprand(1000,1000, 1e-4), (nms, nms)))
 @test startswith(lines[1], "1000×1000 Named sparse matrix with")
 @test endswith(lines[1], "Float64 nonzero entries:")
 @test sum([contains(line, "⋮") for line in lines]) == 1
+
+# array with Nullable names
+lines = showlines(NamedArray(rand(2, 2), (Nullable["a", Nullable()], Nullable["c", "d"])))
+@test lines[1] == "2$(times)2 Named Array{Float64,2}"
+if VERSION >= v"0.5.0-"
+    @test split(lines[2]) == ["A", "╲", "B", "│", "\"c\"", "\"d\""]
+    @test startswith(lines[4], "\"a\"")
+    @test startswith(lines[5], "#NULL")
+else
+    @test split(lines[2]) == ["A","╲","B","│","Nullable(\"c\")","Nullable(\"d\")"]
+    @test startswith(lines[4], "Nullable(\"a\")")
+    @test startswith(lines[5], "Nullable")
+end


### PR DESCRIPTION
This is essential for types such as Nullable, for which the default
representation from show() is quite verbose. Unfortunately, for now,
there is no generic mechanism in Julia Base to get rid of quotes when
printing Nullable{String}, but this is better than nothing.