### PR TITLE
Fix some issues with Julia 0.6 and require Julia 0.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 sudo: false
 language: julia
 julia:
- - 0.4
  - 0.5
+ - 0.6
 before_install:
  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
 script:

--- a/README.md
+++ b/README.md
@@ -4,9 +4,8 @@ NamedArrays
 Julia type that implements a drop-in replacement of Array with named dimensions.
 
 [![Build Status](https://travis-ci.org/davidavdav/NamedArrays.jl.svg)](https://travis-ci.org/davidavdav/NamedArrays.jl)
-[![NamedArrays](http://pkg.julialang.org/badges/NamedArrays_0.3.svg)](http://pkg.julialang.org/?pkg=NamedArrays)
-[![NamedArrays](http://pkg.julialang.org/badges/NamedArrays_0.4.svg)](http://pkg.julialang.org/?pkg=NamedArrays)
 [![NamedArrays](http://pkg.julialang.org/badges/NamedArrays_0.5.svg)](http://pkg.julialang.org/?pkg=NamedArrays)
+[![NamedArrays](http://pkg.julialang.org/badges/NamedArrays_0.6.svg)](http://pkg.julialang.org/?pkg=NamedArrays)
 [![Coverage Status](https://coveralls.io/repos/github/davidavdav/NamedArrays.jl/badge.svg?branch=master)](https://coveralls.io/github/davidavdav/NamedArrays.jl?branch=master)
 
 Idea
@@ -277,11 +276,11 @@ Implementation
 Currently, the type is defined as
 
 ```julia
-type NamedArray{T,N,DT} <: AbstractArray{T,N}
-    array::Array{T,N}
+type NamedArray{T,N,AT,DT} <: AbstractArray{T,N}
+    array::AT
     dicts::DT
-    dimnames::NTuple{N}
-}
+    dimnames::NTuple{N, Any}
+end
 ```
 
-but the inner constructor actually expects `NTuple`s for `names` and `dimnames`, which more easily allows somewhat stricter typechecking.   This is sometimes a bit annoying, if you want to initialize a new NamedArray from known `names` and `dimnames`.  You can use the expression `tuple(Vector...)` for that.
+but the inner constructor actually expects `NTuple`s for `dicts` and `dimnames`, which more easily allows somewhat stricter typechecking.   This is sometimes a bit annoying, if you want to initialize a new NamedArray from known `dicts` and `dimnames`.  You can use the expression `tuple(Vector...)` for that.

--- a/README.md
+++ b/README.md
@@ -37,9 +37,9 @@ Construction
 
 ```julia
 # NamedArray(a::Array)
-x = NamedArray(Int[1 2; 3 4])
-# NamedArray(::Type{T}, dims...)
-x = NamedArray(Int, 2, 2)
+x = NamedArray([1 2; 3 4])
+# NamedArray{T}(dims...)
+x = NamedArray{Int}(2, 2)
 ```
 
 these constructors add default names to the array of type String, "1",
@@ -51,15 +51,15 @@ NamedArray of element type `T` with the specified dimensions `dims...`.
 
 ```julia
 # NamedArray{T,N}(a::Array{T,N}, names::NTuple{N,Dict}, dimnames::NTuple{N})
-x = NamedArray(Int[1 3; 2 4], ( ["A"=>1,"B"=>2], ["C"=>1,"D"=>2] ), ("ROWS","COLS"))
+x = NamedArray([1 3; 2 4], ( ["A"=>1,"B"=>2], ["C"=>1,"D"=>2] ), ("ROWS","COLS"))
 ```
 This is the basic constructor for a namedarray.  `names` must be a tuple of `Dict`s whose range (the values) are exacly covering the range `1:size(a,dim)` for each dimension `dim`.   The keys in the various dictionaries may be of mixed types, but after initialization, the type of the names cannot be altered.  `dimnames` specify the names of the dimensions themselves, and may be of any type.
 
 ```julia
 # NamedArray{T,N}(a::Array{T,N}, names::NTuple{N,Vector}, dimnames::NTuple{N})
-x = NamedArray(Int[1 3; 2 4], ( ["A","B"], ["C","D"] ), ("ROWS","COLS"))
+x = NamedArray([1 3; 2 4], ( ["A","B"], ["C","D"] ), ("ROWS","COLS"))
 # NamedArray{T,N}(a::Array{T,N}, names::NTuple{N,Vector})
-x = NamedArray(Int[1 3; 2 4], ( ["A","B"], ["C","D"] ))
+x = NamedArray([1 3; 2 4], ( ["A","B"], ["C","D"] ))
 ```
 This is a more friendly version of the basic constructor, where the range of the dictionaries is automatically assigned the values `1:size(a,dim)` for the `names` in order. If `dimnames` is not specified, the default values will be used (`:A`, `:B`, etc.).
 

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,4 @@
-julia 0.4
+julia 0.5
 Combinatorics 0.2.1
 DataStructures 0.4.4
+Compat 0.18

--- a/src/NamedArrays.jl
+++ b/src/NamedArrays.jl
@@ -19,7 +19,6 @@ include("namedarraytypes.jl")
 
 export names, dimnames, defaultnames, setnames!, setdimnames!, array
 
-include("compat.jl")
 include("constructors.jl")
 include("arithmetic.jl")
 include("base.jl")

--- a/src/arithmetic.jl
+++ b/src/arithmetic.jl
@@ -90,11 +90,9 @@ end
 
 import Base: A_mul_B!, A_mul_Bc!, A_mul_Bc, A_mul_Bt!, A_mul_Bt, Ac_mul_B, Ac_mul_B!, Ac_mul_Bc, Ac_mul_Bc!, At_mul_B, At_mul_B!, At_mul_Bt, At_mul_Bt!
 
-if VERSION ≥ v"0.5.0" ## v0.4 ambiguity-hell with AbstractTriangular c.s.
-    ## Assume dimensions/names are correct
-    for op in (:A_mul_B!, :A_mul_Bc!, :A_mul_Bt!, :Ac_mul_B!, :Ac_mul_Bc!, :At_mul_B!, :At_mul_Bt!)
-        @eval ($op)(C::NamedMatrix, A::AbstractMatrix, B::AbstractMatrix) = ($op)(C.array, A, B)
-    end
+## Assume dimensions/names are correct
+for op in (:A_mul_B!, :A_mul_Bc!, :A_mul_Bt!, :Ac_mul_B!, :Ac_mul_Bc!, :At_mul_B!, :At_mul_Bt!)
+    @eval ($op)(C::NamedMatrix, A::AbstractMatrix, B::AbstractMatrix) = ($op)(C.array, A, B)
 end
 
 for op in (:A_mul_Bc, :A_mul_Bt)

--- a/src/arithmetic.jl
+++ b/src/arithmetic.jl
@@ -5,14 +5,21 @@
 ## This code is licensed under the MIT License
 ## See the file LICENSE.md in this distribution
 
-import Base: +, -, *, /, .+, .-, .*, ./, \
+import Base: +, -, *, /
+if VERSION < v"0.6.0-dev.1632"
+    @eval import Base: .+, .-, .*, ./, \
+end
 
 -(n::NamedArray) = NamedArray(-n.array, n.dicts, n.dimnames)
 
 ## disambiguation magic
-.*(n::NamedArray{Bool}, b::BitArray) = NamedArray(n.array .* b, n.dicts, n.dimnames)
-.*{N}(n::NamedArray{Bool,N}, b::BitArray{N}) = NamedArray(n.array .* b, n.dicts, n.dimnames)
-.*{N}(b::BitArray{N}, n::NamedArray{Bool,N}) = n .* b
+if VERSION < v"0.6.0-dev.1632"
+    @eval begin
+        .*(n::NamedArray{Bool}, b::BitArray) = NamedArray(n.array .* b, n.dicts, n.dimnames)
+        .*{N}(n::NamedArray{Bool,N}, b::BitArray{N}) = NamedArray(n.array .* b, n.dicts, n.dimnames)
+        .*{N}(b::BitArray{N}, n::NamedArray{Bool,N}) = n .* b
+    end
+end
 
 # disambiguation (Argh...)
 for op in (:+, :-)
@@ -20,7 +27,24 @@ for op in (:+, :-)
     @eval ($op){T1<:Number,T2<:Number}(x::NamedVector{T1}, y::Range{T2}) = NamedArray(($op)(x.array, y), x.dicts, x.dimnames)
 end
 
-for op in (:+, :-, :.+, :.-, :.*, :./)
+if VERSION < v"0.6.0-dev.1632"
+    for op in (:.+, :.-, :.*, :./)
+        @eval begin
+            function ($op){T1<:Number, T2<:Number}(x::NamedArray{T1}, y::NamedArray{T2})
+                if names(x) == names(y) && x.dimnames == y.dimnames
+                    NamedArray(($op)(x.array, y.array), x.dicts, x.dimnames)
+                else
+                    warn("Dropping mismatching names")
+                    ($op)(x.array, y.array)
+                end
+            end
+            ($op){T1<:Number,T2<:Number,N}(x::NamedArray{T1,N}, y::AbstractArray{T2,N}) = NamedArray(($op)(x.array, y), x.dicts, x.dimnames)
+            ($op){T1<:Number,T2<:Number,N}(x::AbstractArray{T1,N}, y::NamedArray{T2,N}) = NamedArray(($op)(x, y.array), y.dicts, y.dimnames)
+        end
+    end
+end
+
+for op in (:+, :-)
     ## named %op% named
     @eval begin
         function ($op){T1<:Number, T2<:Number}(x::NamedArray{T1}, y::NamedArray{T2})
@@ -46,7 +70,16 @@ for op in (:+, :-)
 end
 
 ## NamedArray, Number
-for op in (:+, :-, :*, :.+, :.-, :.*, :./)
+if VERSION < v"0.6.0-dev.1632"
+    for op in (:.+, :.-, :.*, :./)
+        @eval begin
+            ($op){T1<:Number,T2<:Number}(x::NamedArray{T1}, y::T2) = NamedArray(($op)(x.array, y), x.dicts, x.dimnames)
+            ($op){T1<:Number,T2<:Number}(x::T1, y::NamedArray{T2}) = NamedArray(($op)(x, y.array), y.dicts, y.dimnames)
+        end
+    end
+end
+
+for op in (:+, :-, :*)
     @eval begin
         ($op){T1<:Number,T2<:Number}(x::NamedArray{T1}, y::T2) = NamedArray(($op)(x.array, y), x.dicts, x.dimnames)
         ($op){T1<:Number,T2<:Number}(x::T1, y::NamedArray{T2}) = NamedArray(($op)(x, y.array), y.dicts, y.dimnames)
@@ -87,7 +120,7 @@ for op in (:Ac_mul_Bc, :At_mul_Bt)
 end
 
 import Base.LinAlg: Givens, BlasFloat, lufact!, LU, ipiv2perm, cholfact!, cholfact, qrfact!, qrfact, eigfact!, eigfact, eigvals!,
-    eigvals, hessfact, hessfact!, schurfact!, schurfact, svdfact!, svdfact, svdvals!, svdvals, svd, diag, diagm, scale!, scale,
+    eigvals, hessfact, hessfact!, schurfact!, schurfact, svdfact!, svdfact, svdvals!, svdvals, svd, diag, diagm, scale!,
     cond, kron, linreg, lyap, sylvester, isposdef
 
 ## matmul

--- a/src/compat.jl
+++ b/src/compat.jl
@@ -1,8 +1,0 @@
-## inspired by DataFrames
-if VERSION < v"0.5.0-dev+2023"
-    displaysize(io::IO) = Base.tty_size()
-end
-
-if !isdefined(Core, :String)
-    String = ASCIIString
-end

--- a/src/constructors.jl
+++ b/src/constructors.jl
@@ -61,6 +61,4 @@ function NamedArray(T::DataType, dims::Int...)
     NamedArray(a, tuple(names...), tuple(dimnames...))
 end
 
-if VERSION >= v"0.5.0-dev+2396"
-    include("typedconstructor.jl")
-end
+(::Type{NamedArray{T}}){T}(n) = NamedArray(Array{T}(n))

--- a/src/constructors.jl
+++ b/src/constructors.jl
@@ -12,29 +12,24 @@ letter(i) = string(Char((64+i) % 256))
 defaultnames(dim::Integer) = map(string, 1:dim)
 defaultnamesdict(names::Vector) = OrderedDict(zip(names, 1:length(names)))
 defaultnamesdict(dim::Integer) = defaultnamesdict(defaultnames(dim))
-defaultnamesdict(dims::NTuple) = map(defaultnamesdict, dims)
+defaultnamesdict(dims::Tuple) = map(defaultnamesdict, dims)
 
 defaultdimname(dim::Integer) = Symbol(letter(dim))
 defaultdimnames(ndim::Integer) = map(defaultdimname, tuple(1:ndim...))
 defaultdimnames(a::AbstractArray) = defaultdimnames(ndims(a))
 
 ## disambiguation (Argh...)
-NamedArray{T,N}(a::AbstractArray{T,N}, names::Tuple{}, dimnames::NTuple{N}) = NamedArray{T,N,typeof(a),Tuple{}}(a, (), ())
+NamedArray{T,N}(a::AbstractArray{T,N}, names::Tuple{}, dimnames::NTuple{N, Any}) = NamedArray{T,N,typeof(a),Tuple{}}(a, (), ())
 NamedArray{T,N}(a::AbstractArray{T,N}, names::Tuple{}) = NamedArray{T,N,typeof(a),Tuple{}}(a, (), ())
 
 ## Basic constructor: array, tuple of dicts, tuple
-## This calls the inner constructor with the appropriate types
-function NamedArray{T,N}(a::AbstractArray{T,N}, names::NTuple{N,OrderedDict}, dimnames::NTuple{N})
-    NamedArray{T, N, typeof(a), typeof(names)}(a, names, dimnames) ## inner constructor
-end
-
 ## dimnames created as default, then inner constructor called
 function NamedArray{T,N}(array::AbstractArray{T,N}, names::NTuple{N,OrderedDict})
     NamedArray{T, N, typeof(array), typeof(names)}(array, names, defaultdimnames(array)) ## inner constructor
 end
 
 ## constructor with array, names and dimnames (dict is created from names)
-function NamedArray{T,N}(array::AbstractArray{T,N}, names::NTuple{N,Vector}, dimnames::NTuple{N}=defaultdimnames(array))
+function NamedArray{T,N}(array::AbstractArray{T,N}, names::NTuple{N,Vector}, dimnames::NTuple{N, Any}=defaultdimnames(array))
     dicts = defaultnamesdict(names)
     NamedArray(array, dicts, dimnames)
 end
@@ -62,7 +57,7 @@ function NamedArray(T::DataType, dims::Int...)
     ld = length(dims)
     names = [[string(j) for j=1:i] for i=dims]
     dimnames = [Symbol(letter(i)) for i=1:ld]
-    a = Array(T, dims...)
+    a = Array{T}(dims...)
     NamedArray(a, tuple(names...), tuple(dimnames...))
 end
 

--- a/src/index.jl
+++ b/src/index.jl
@@ -154,8 +154,6 @@ getindex{T,N}(n::NamedArray{T,N}, I::CartesianIndex{N}) = getindex(n.array, I)
 
 import Base.setindex!
 
-setindex!{T}(A::NamedArray{T}, x) = setindex!(A, convert(T,x), 1)
-
 if VERSION < v"0.5"
     setindex!{T}(n::NamedArray{T}, x, i1::Real) = setindex!(n.array, convert(T,x), indices(n.dicts[1],i1))
     setindex!{T}(n::NamedArray{T}, x, i1::Real, i2::Real) = setindex!(n.array, convert(T,x), indices(n.dicts[1], i1), indices(n.dicts[2], i2))

--- a/src/keepnames.jl
+++ b/src/keepnames.jl
@@ -49,19 +49,7 @@ function Base.vcat(N::NamedVector...)
 end
 
 ## broadcast
-if VERSION < v"0.5"
-    Base.Broadcast.broadcast(f, n::NamedArray, As...) = broadcast!(f, similar(n, Base.Broadcast.broadcast_shape(n, As...)), n, As...)
-else
-    Base.Broadcast.broadcast_t(f, T, n::NamedArray, As...) = broadcast!(f, similar(n, T, Base.Broadcast.broadcast_shape(n, As...)), n, As...)
-end
-
-## keep names intact
-if VERSION < v"0.5"
-    for f in (:sin, :cos, :tan, :sind, :cosd, :tand, :sinpi, :cospi, :sinh, :cosh, :tanh, :asin, :acos, :atan, :asind, :acosd, :sec, :csc, :cot, :secd, :cscd, :cotd, :asec, :acsc, :asecd, :acscd, :acotd, :sech, :csch, :coth, :asinh, :acosh, :atanh, :asech, :acsch, :acoth, :sinc, :cosc, :deg2rad, :log, :log2, :log10, :log1p, :exp, :exp2, :exp10, :expm1, :ceil, :floor, :trunc, :round, :abs, :abs2, :sign, :signbit, :sqrt, :isqrt, :cbrt, :erf, :erfc, :erfcx, :erfi, :dawson, :erfinv, :erfcinv, :real, :imag, :conj, :angle, :cis, :gamma, :lgamma, :digamma, :invdigamma, :trigamma, :airyai, :airyprime, :airyaiprime, :airybi, :airybiprime, :besselj0, :besselj1, :bessely0, :bessely1, :eta, :zeta)
-        eval(Expr(:import, :Base, f))
-        @eval ($f)(a::NamedArray) = NamedArray(($f)(a.array), a.dicts, a.dimnames)
-    end
-end
+Base.Broadcast.broadcast_t(f, T, n::NamedArray, As...) = broadcast!(f, similar(n, T, Base.Broadcast.broadcast_shape(n, As...)), n, As...)
 
 ## reorder names
 import Base: sort, sort!

--- a/src/namedarraytypes.jl
+++ b/src/namedarraytypes.jl
@@ -6,6 +6,8 @@
 ## This code is licensed under the MIT license
 ## See the file LICENSE.md in this distribution
 
+using Compat
+
 ## DT is a tuple of Dicts, characterized by the types of the keys.
 ## This way NamedArray is dependent on the dictionary type of each dimensions.
 ## The inner constructor checks for consistency, the values must all be 1:d
@@ -14,13 +16,13 @@ if !isdefined(:NamedArray)
 type NamedArray{T,N,AT,DT} <: AbstractArray{T,N}
     array::AT
     dicts::DT
-    dimnames::NTuple{N}
-    function NamedArray(array::AbstractArray{T,N}, dicts::NTuple{N,OrderedDict}, dimnames::NTuple{N})
+    dimnames::NTuple{N, Any}
+    function (::Type{S}){S<:NamedArray, T, N}(array::AbstractArray{T, N}, dicts::NTuple{N, OrderedDict}, dimnames::NTuple{N, Any})
         size(array) == map(length, dicts) || error("Inconsistent dictionary sizes")
 #        for (d,dict) in zip(size(array),dicts)
 #            Set(values(dict)) == Set(1:d) || error("Inconsistent values in dict")
 #        end
-        new(array, dicts, dimnames)
+        new{T,N,typeof(array),typeof(dicts)}(array, dicts, dimnames)
     end
 end
 
@@ -30,9 +32,9 @@ immutable Not{T}
     index::T
 end
 
-typealias NamedVector{T} NamedArray{T,1}
-typealias NamedMatrix{T} NamedArray{T,2}
-typealias NamedVecOrMat{T} Union{NamedVector{T},NamedMatrix{T}}
-typealias ArrayOrNamed{T,N} Union{Array{T,N}, NamedArray{T,N,Array}}
+@compat NamedVector{T} = NamedArray{T,1}
+@compat NamedMatrix{T} = NamedArray{T,2}
+@compat NamedVecOrMat{T} = Union{NamedVector{T},NamedMatrix{T}}
+@compat ArrayOrNamed{T,N} = Union{Array{T,N}, NamedArray{T,N,Array}}
 
 end

--- a/src/rearrange.jl
+++ b/src/rearrange.jl
@@ -54,11 +54,7 @@ rotr90(n::NamedArray) = transpose(flipdim(n, 1))
 rotl90(n::NamedArray) = transpose(flipdim(n, 2))
 rot180(n::NamedArray) = NamedArray(rot180(n.array), tuple([reverse(name) for name in names(n)]...), n.dimnames)
 
-if VERSION < v"0.5"
-    import Base.nthperm, Base.nthperm!
-else
-    import Combinatorics.nthperm, Combinatorics.nthperm!
-end
+import Combinatorics.nthperm, Combinatorics.nthperm!
 import Base.permute!, Base.ipermute!, Base.shuffle, Base.shuffle!, Base.reverse, Base.reverse!
 function nthperm(v::NamedVector, n::Int)
     newnames = nthperm(names(v,1), n)

--- a/src/show.jl
+++ b/src/show.jl
@@ -21,9 +21,6 @@ print(n::NamedArray) = print(n.array)
 
 ## This seems to be the essential function to overload for displaying in REPL:
 Base.show(io::IO, ::MIME"text/plain", n::NamedArray) = show(io, n)
-if VERSION < v"0.5.0-dev+4356"
-    Base.writemime(io::IO, ::MIME"text/plain", n::NamedArray) = show(io, n)
-end
 
 ## ndims==1 is dispatched below
 function show(io::IO, n::NamedArray)

--- a/src/typedconstructor.jl
+++ b/src/typedconstructor.jl
@@ -1,4 +1,0 @@
-## Only read this for julia-0.5 and up
-
-## default / fallback Constructors
-(::Type{NamedArray{T}}){T}(n) = NamedArray(Array{T}(n))

--- a/test/arithmetic.jl
+++ b/test/arithmetic.jl
@@ -62,18 +62,16 @@ end
 @test ((1:6) - v).array == (1:6) - v.array
 
 ## matmul
-if VERSION ≥ v"0.5" ## v0.4 ambiguity-hell with AbstractTriangular c.s.
-    ## Assume dimensions/names are correct
-	c = NamedArray(Float64, 5, 5)
-	r5x10 = randn(5, 10)
-	r10x5 = randn(10, 5)
-	@test A_mul_B!(c, r5x10, r10x5) == r5x10 * r10x5
-	@test A_mul_Bc!(c, r5x10, r5x10) == r5x10 * r5x10'
-	@test A_mul_Bt!(c, r5x10, r5x10) == r5x10 * r5x10'
-	@test Ac_mul_B!(c, r10x5, r10x5) == r10x5' * r10x5
-	@test At_mul_B!(c, r10x5, r10x5) == r10x5' * r10x5
-	@test At_mul_Bt!(c, r10x5, r5x10) == r10x5' * r5x10'
-end
+## Assume dimensions/names are correct
+c = NamedArray(Float64, 5, 5)
+r5x10 = randn(5, 10)
+r10x5 = randn(10, 5)
+@test A_mul_B!(c, r5x10, r10x5) == r5x10 * r10x5
+@test A_mul_Bc!(c, r5x10, r5x10) == r5x10 * r5x10'
+@test A_mul_Bt!(c, r5x10, r5x10) == r5x10 * r5x10'
+@test Ac_mul_B!(c, r10x5, r10x5) == r10x5' * r10x5
+@test At_mul_B!(c, r10x5, r10x5) == r10x5' * r10x5
+@test At_mul_Bt!(c, r10x5, r5x10) == r10x5' * r5x10'
 
 for m in (NamedArray(rand(4)), NamedArray(rand(4,3)))
     @test m * m' == m.array * m.array'
@@ -153,9 +151,7 @@ lufa = lufact(n.array)
 a = randn(1000,10); s = NamedArray(a'a)
 
 ## The necessity for isapprox sugests we don't get BLAS implementations but a fallback...
-if VERSION ≥ v"0.5" ## v0.4 cholfact is different?
-	@test isapprox(cholfact(s).factors.array, cholfact(s.array).factors)
-end
+@test isapprox(cholfact(s).factors.array, cholfact(s.array).factors)
 
 @test isapprox(qrfact(s).factors.array, qrfact(s.array).factors)
 # @test isapprox(qrfact(s).T, qrfact(s.array).T)

--- a/test/index.jl
+++ b/test/index.jl
@@ -31,9 +31,6 @@ first = n.array[1,:]
 @test names(n[Not("two"), :]) == names(n[1:1, :])
 @test n[:, ["b", "d"]] == view(n, :, ["b", "d"]) == n[:, [2, 4]]
 
-if VERSION < v"0.5"
-    @test names(n["one", :],1) == ["one"]
-end
 @test names(n[Not("one"), :],1) == ["two"]
 @test names(n[1:1, Not("a")], 2) == ["b", "c", "d"]
 ## indexing by pair

--- a/test/init-namedarrays.jl
+++ b/test/init-namedarrays.jl
@@ -1,9 +1,6 @@
 n = NamedArray(rand(2,4))
 Letters = [string(Char(64+i)) for i in 1:26]
 letters = [string(Char(64+32+i)) for i in 1:26]
-if VERSION < v"0.5"
-	letters = ASCIIString[ascii(s) for s in letters]
-end
 
 setnames!(n, ["one", "two"], 1)
 setnames!(n, letters[1:4], 2)

--- a/test/names.jl
+++ b/test/names.jl
@@ -9,13 +9,8 @@ include("init-namedarrays.jl")
 @test dimnames(n.array, 1) == :A
 @test dimnames(n.array, 2) == :B
 
-if VERSION ≥ v"0.5" ## ascii and utf-8 are both String
-	dn1 = ["一", "二"]
-	dn2 = ["一", "二", "三", "四"]
-else
-	dn1 = ["yi", "er"]
-	dn2 = ["yi", "er", "san", "si"]
-end
+dn1 = ["一", "二"]
+dn2 = ["一", "二", "三", "四"]
 
 setnames!(n, dn1, 1)
 for (i, zh) in enumerate(dn2)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,8 +10,4 @@ using NamedArrays
 using Base.Test
 using DataStructures
 
-if VERSION < v"0.5"
-	view(n::NamedArray, args...) = getindex(n, args...)
-end
-
 include("test.jl")

--- a/test/show.jl
+++ b/test/show.jl
@@ -9,18 +9,10 @@ println("show,")
 
 include("init-namedarrays.jl")
 
-if VERSION ≥ v"0.5"
-    tostring(b::IOBuffer) = String(b)
-    times = "×" ## \times
-else
-    tostring(b::IOBuffer) = UTF8String(b.data)
-    times = "x" # ex
-end
-
 function showlines(x...)
     buf = IOBuffer()
     show(buf, x...)
-    return split(tostring(buf), "\n")
+    return split(String(buf), "\n")
 end
 
 lines = showlines(NamedArray(Array{Int}()))
@@ -33,14 +25,14 @@ lines = showlines(NamedArray([]))
 
 for lines in Any[showlines(n), showlines(MIME"text/plain"(), n)]
     @test length(lines) == 5
-    @test lines[1] == "2$(times)4 Named Array{Float64,2}"
+    @test lines[1] == "2×4 Named Array{Float64,2}"
     @test split(lines[2]) == vcat(["A", "╲", "B", "│"], letters[1:4])
 end
 
 ## wide array abbreviated
 lines = showlines(NamedArray(randn(2,1000)))
 @test length(lines) == 5
-@test lines[1] == "2$(times)1000 Named Array{Float64,2}"
+@test lines[1] == "2×1000 Named Array{Float64,2}"
 header = split(lines[2])
 @test header[vcat(1:5, end)] == ["A", "╲", "B", "│", "1", "1000"]
 @test "…" in header
@@ -51,7 +43,7 @@ end
 ## tall array abbreviated
 lines = showlines(NamedArray(randn(1000,2)))
 @test length(lines) > 7
-@test lines[1] == "1000$(times)2 Named Array{Float64,2}"
+@test lines[1] == "1000×2 Named Array{Float64,2}"
 @test split(lines[2]) == ["A", "╲", "B", "│", "1", "2"]
 @test split(lines[4])[1] == "1"
 @test split(lines[end])[1] == "1000"
@@ -68,7 +60,7 @@ lines = showlines(NamedArray(randn(1000)))
 zo = [0,1]
 lines = showlines(NamedArray(rand(2,2,2), (zo, zo, zo), ("base", "zero", "indexing")))
 @test length(lines) == 13
-@test lines[1] == "2$(times)2$(times)2 Named Array{Float64,3}"
+@test lines[1] == "2×2×2 Named Array{Float64,3}"
 
 for (index, offset) in ([0, 3], [1, 9])
     @test lines[offset] == "[:, :, indexing=$index] ="
@@ -82,7 +74,7 @@ for ndim in 1:5
     if (ndim == 1)
         line1 = "2-element Named Array{Float64,1}"
     else
-        line1 = join(repmat(["2"], ndim), times) * " Named Array{Float64,$ndim}"
+        line1 = join(repmat(["2"], ndim), "×") * " Named Array{Float64,$ndim}"
     end
     @test lines[1] == line1
     if ndim ≥ 3
@@ -105,13 +97,7 @@ lines = showlines(NamedArray(sprand(1000,1000, 1e-4), (nms, nms)))
 
 # array with Nullable names
 lines = showlines(NamedArray(rand(2, 2), (Nullable["a", Nullable()], Nullable["c", "d"])))
-@test lines[1] == "2$(times)2 Named Array{Float64,2}"
-if VERSION >= v"0.5.0-"
-    @test split(lines[2]) == ["A", "╲", "B", "│", "\"c\"", "\"d\""]
-    @test startswith(lines[4], "\"a\"")
-    @test startswith(lines[5], "#NULL")
-else
-    @test split(lines[2]) == ["A","╲","B","│","Nullable(\"c\")","Nullable(\"d\")"]
-    @test startswith(lines[4], "Nullable(\"a\")")
-    @test startswith(lines[5], "Nullable")
-end
+@test lines[1] == "2×2 Named Array{Float64,2}"
+@test split(lines[2]) == ["A", "╲", "B", "│", "\"c\"", "\"d\""]
+@test startswith(lines[4], "\"a\"")
+@test startswith(lines[5], "#NULL")

--- a/test/test.jl
+++ b/test/test.jl
@@ -67,13 +67,11 @@ for i1=1:2, i2=1:3, i3=1:4, i4=1:3, i5=1:2, i6=1:3
     @test m[string(i1), string(i2), string(i3), string(i4), string(i5), string(i6)] == m.array[i1,i2,i3,i4,i5,i6]
 end
 m[1, :, 2, :, 2, 3].array == m.array[1, :, 2, :, 2, 3]
-if VERSION ≥ v"0.5"
-    i = [3 2 4; 1 4 2]
-    @test n[:, i].array == n.array[:, i]
-    @test names(n[:, i], 1) == names(n, 1)
-    @test names(n[:, i], 2) == map(string, 1:2)
-    @test names(n[:, i], 3) == map(string, 1:3)
-end
+i = [3 2 4; 1 4 2]
+@test n[:, i].array == n.array[:, i]
+@test names(n[:, i], 1) == names(n, 1)
+@test names(n[:, i], 2) == map(string, 1:2)
+@test names(n[:, i], 3) == map(string, 1:3)
 
 print("dodgy indices, ")
 ## weird indices
@@ -111,22 +109,16 @@ print("vectorized, ")
 
 ## a selection of vectorized functions
 for f in  (:sin, :cos, :tan,  :sinpi, :cospi, :sinh, :cosh, :tanh, :asin, :acos, :atan, :sinc, :cosc, :deg2rad, :log, :log2, :log10, :log1p, :exp, :exp2, :exp10, :expm1, :abs, :abs2, :sign, :sqrt,  :erf, :erfc, :erfcx, :erfi, :dawson, :erfinv, :erfcinv, :gamma, :lgamma, :digamma, :invdigamma, :trigamma, :besselj0, :besselj1, :bessely0, :bessely1, :eta, :zeta)
-    if VERSION < v"0.5"
-        @eval @test ($f)(n).array == ($f)(n.array)
-    else
-        @eval begin
-            m = ($f).(n)
-            @test m.array == ($f).(n.array)
-            @test namesanddim(m) == namesanddim(n)
-        end
+    @eval begin
+        m = ($f).(n)
+        @test m.array == ($f).(n.array)
+        @test namesanddim(m) == namesanddim(n)
     end
 end
 #39
-if VERSION ≥ v"0.5"
-    v = n[1,:]
-    @test sin.(v).array == sin.(v.array)
-    @test namesanddim(sin.(v)) == namesanddim(v)
-end
+v = n[1,:]
+@test sin.(v).array == sin.(v.array)
+@test namesanddim(sin.(v)) == namesanddim(v)
 
 include("rearrange.jl")
 
@@ -142,10 +134,8 @@ include("show.jl")
 
 include("speed.jl")
 
-if VERSION ≥ v"0.5"
-    # julia issue #17328
-    a = NamedArray([1.0,2.0,3.0,4.0])
-    @test sumabs(a, 1)[1] == 10
-end
+# julia issue #17328
+a = NamedArray([1.0,2.0,3.0,4.0])
+@test sumabs(a, 1)[1] == 10
 
 println("done!")


### PR DESCRIPTION
This fixes some failures and deprecation warnings, but not all of them.
In particular, the broadcast code needs deeper changes.

See the first commit, the second one just removes all 0.5-only code and makes the diff quite noisy.

This does not fix all the tests on 0.6, but at least allows FreqTables to pass its tests.