### PR TITLE
Use isdefined instead of VERSION ≥ v0.6.0-dev for RowVector and 0.6 broadcast

### DIFF
--- a/src/arithmetic.jl
+++ b/src/arithmetic.jl
@@ -134,7 +134,7 @@ end
 ## Named * Named
 *(A::NamedMatrix, B::NamedMatrix) = NamedArray(A.array * B.array, (A.dicts[1], B.dicts[2]), (A.dimnames[1], B.dimnames[2]))
 *(A::NamedMatrix, B::NamedVector) = NamedArray(A.array * B.array, (A.dicts[1],), (B.dimnames[1],))
-if VERSION ≥ v"0.6.0-dev"
+if isdefined(Base, :RowVector)
     *(A::NamedRowVector, B::NamedVector) = A.array * B.array
 end
 ## Named * Abstract
@@ -142,7 +142,7 @@ end
 *(A::AbstractMatrix, B::NamedMatrix) = NamedArray(A * B.array, (defaultnamesdict(size(A,1)), B.dicts[2]), B.dimnames)
 *(A::NamedMatrix, B::AbstractVector) = NamedArray(A.array * B, (A.dicts[1],), (A.dimnames[1],))
 *(A::AbstractMatrix, B::NamedVector) = A * B.array
-if VERSION ≥ v"0.6.0-dev"
+if isdefined(Base, :RowVector)
     *(A::NamedRowVector, B::AbstractVector) = A.array * B
 end
 ## \ --- or should we overload A_div_B?

--- a/src/keepnames.jl
+++ b/src/keepnames.jl
@@ -51,13 +51,17 @@ end
 ## broadcast v0.5
 Base.Broadcast.broadcast_t(f, T, n::NamedArray, As...) = broadcast!(f, similar(n, T, Base.Broadcast.broadcast_shape(n, As...)), n, As...)
 ## broadcast v0.6
-if VERSION ≥ v"0.6.0-dev"
+if isdefined(Base.Broadcast, :_containertype)
     Base.Broadcast._containertype(::Type{<:NamedArray}) = NamedArray
+end
+if isdefined(Base.Broadcast, :promote_containertype)
     Base.Broadcast.promote_containertype(::Type{NamedArray}, _) = NamedArray
     Base.Broadcast.promote_containertype(_, ::Type{NamedArray}) = NamedArray
     Base.Broadcast.promote_containertype(::Type{NamedArray}, ::Type{Array}) = NamedArray
     Base.Broadcast.promote_containertype(::Type{Array}, ::Type{NamedArray}) = NamedArray
     Base.Broadcast.promote_containertype(::Type{NamedArray}, ::Type{NamedArray}) = NamedArray
+end
+if isdefined(Base.Broadcast, :broadcast_c)
     #function Base.Broadcast.broadcast_c(f, ::Type{NamedArray}, n::NamedArray, As...)#
     #    a = similar(n.array)
     #    broadcast!(f, a, n, As...)

--- a/src/namedarraytypes.jl
+++ b/src/namedarraytypes.jl
@@ -37,7 +37,7 @@ end
 @compat NamedVecOrMat{T} = Union{NamedVector{T},NamedMatrix{T}}
 @compat ArrayOrNamed{T,N} = Union{Array{T,N}, NamedArray{T,N,Array}}
 
-if VERSION ≥ v"0.6.0-dev"
+if isdefined(Base, :RowVector)
     @compat NamedRowVector{T,RVT<:AbstractVector} = NamedArray{T,2,RowVector{T,RVT}}
 end
 


### PR DESCRIPTION
will be more specific about only using/extending functions or types when they exist