### PR TITLE
Solve *(NamedMatrix, NamedMatrix) name problems in Julia 0.7

### DIFF
--- a/src/linearalgebra.jl
+++ b/src/linearalgebra.jl
@@ -3,3 +3,15 @@ Base.strides(n::NamedArray) = Base.strides(n.array)
 Base.unsafe_convert(p::Type{Ptr{T}}, n::NamedArray) where T = Base.unsafe_convert(p, n.array)
 
 # TODO: solve TODO problems in tests for arithmetic here using the new LinearAlgebra stdlib
+
+# Based in LinearAlgebra/src/matmul.jl: *(A::AbstractArray{T,2}, B::AbstractArray{T,2})
+function Base.:*(A::NamedArray{TA, 2, ATA, NTA},
+                 B::NamedArray{TB, 2, ATB, NTB}) where {TA, TB, ATA, ATB, NTA, NTB}
+    TS = Base.promote_op(LinearAlgebra.matprod, TA, TB)
+    out_size = (size(A,1), size(B,2))
+    dump(out_size)
+    out = NamedArray(Array{TS}(undef, out_size),
+                     (A.dicts[1], B.dicts[2]),
+                     (A.dimnames[1], B.dimnames[2]))
+    mul!(out, A.array, B.array)
+end

--- a/test/arithmetic.jl
+++ b/test/arithmetic.jl
@@ -77,8 +77,8 @@ for M in (NamedArray(rand(4)), NamedArray(rand(4,3)))
 end
 
 ## bug #34
-# TODO: @test unique(names(n * n'))[1] == names(n, 1)
-# TODO: @test unique(names(n' * n))[1] == names(n, 2)
+@test unique(names(n * n'))[1] == names(n, 1)
+@test unique(names(n' * n))[1] == names(n, 2)
 
 ## \
 v = NamedArray(randn(2))

--- a/test/index.jl
+++ b/test/index.jl
@@ -31,8 +31,7 @@ n1 = @inferred NamedArray(rand(10))
 @test [x for x in n] == [x for x in n.array]
 
 ## more indexing
-first = n.array[1,:]
-@test convert(Array, n["one", :]) == first
+@test convert(Array, n["one", :]) == n.array[1,:]
 @test n[Not("two"), :].array == n.array[1:1,:]
 @test names(n[Not("two"), :]) == names(n[1:1, :])
 @test n[:, ["b", "d"]] == view(n, :, ["b", "d"]) == n[:, [2, 4]]


### PR DESCRIPTION
This solves one of the TODO annotated tests in arithmetic.

Hint on the others: I saw that others TODO tests are failing because of `transpose` and `permutedims`, that are changed in Julia 0.7.

Cheers,