### PR TITLE
Added DataFrame <-> NamedArray type conversion and tests.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.9.4"
 
 [deps]
 Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"
+DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"
 InvertedIndices = "41ab1584-1d38-5bbf-9106-f11c6c58b48f"

--- a/src/convert.jl
+++ b/src/convert.jl
@@ -22,3 +22,40 @@ convert(::Type{NamedVector}, a::AbstractArray) = NamedArray(a)
 convert(::Type{NamedArray{T}}, n::NamedArray) where {T} = NamedArray(T.(n.array), n.dicts, n.dimnames)
 
 @inline convert(::Type{NamedArray}, n::NamedArray) = n
+
+#= """ =#
+#= Conversion from a Dict to a NamedArray. =#
+#= """ =#
+#= function convert(t::Type{NamedArray}, dict::Dict{K,V}) where {K,V} =#
+#= 	allkeys = collect(keys(dict)) =#
+#= 	allvalues = collect(values(dict)) =#
+#= 	return NamedArray(allvalues, allkeys, (:keys)) =#
+#= end =#
+
+using DataFrames
+"""
+Converts a NamedArray to a DataFrame.
+
+"""
+function convert(t::Type{DataFrame}, n::NamedArray{V}; valueCol = :Values) where {V}
+	mydimnames = n.dimnames
+	mytypes = map(dict->eltype(keys(dict)),n.dicts)
+	dfArgs = map((d,t)-> d=>t[], mydimnames, mytypes)
+	dfArgs = (dfArgs..., valueCol => V[])
+	df = DataFrame(dfArgs...)
+	map(tup -> push!(df,(tup[1]...,tup[2])),enamerate(n))
+	return df
+end
+
+"""
+Converts a DataFrame to a NamedArray.
+"""
+function convert(t::Type{NamedArray}, df::DataFrame; valueCol = :Values)
+	newdimnames = propertynames(df)
+	deleteat!(newdimnames,findfirst(x->x==:Values,newdimnames))
+	names = map(dn->unique(df[!,dn]),newdimnames)
+	lengths = map(length,names)
+	println(names)
+	newna = NamedArray( reshape(df[!,valueCol], lengths...), tuple(names...), tuple(newdimnames...))
+	return newna
+end

--- a/test/convert.jl
+++ b/test/convert.jl
@@ -36,4 +36,12 @@ using DataFrames
 	@test all(map(x-> x in propertynames(cn), dimnames(n)))
 	@test ccn isa NamedArray
 	@test ccn == n
+
+	cm = convert(DataFrame,m)
+	ccm = convert(NamedArray,cm)
+	@test cm isa DataFrame
+	@test all(map(x-> x in m, cm[!,:Values]))
+	@test all(map(x-> x in propertynames(cm), dimnames(m)))
+	@test ccm isa NamedArray
+	@test ccm == m
 end

--- a/test/convert.jl
+++ b/test/convert.jl
@@ -20,17 +20,20 @@ x = @inferred NamedArray(Array([1 2; 3 4]), (["a","b"], [10,11]), (:rows,:cols))
 
 # Test convert don't change array type
 
+using SparseArrays
 n_sparray = NamedArray(SparseArrays.sprand(Int, 5, 5, 0.5))
 @test isa(n_sparray.array, SparseMatrixCSC{Int,Int})
 @test isa(convert(NamedArray{Float64}, n_sparray).array, SparseMatrixCSC{Float64,Int})
 
 using DataFrames
 
-@testset "DataFrame <-> NamedArray" begin
+@testset "convert DataFrame <-> NamedArray" begin
 	# Test conversions to and from DataFrame.
 	cn = convert(DataFrame,n)
 	ccn = convert(NamedArray,cn)
 	@test cn isa DataFrame
+	@test all(map(x-> x in n, cn[!,:Values]))
+	@test all(map(x-> x in propertynames(cn), dimnames(n)))
 	@test ccn isa NamedArray
 	@test ccn == n
 end

--- a/test/convert.jl
+++ b/test/convert.jl
@@ -23,3 +23,14 @@ x = @inferred NamedArray(Array([1 2; 3 4]), (["a","b"], [10,11]), (:rows,:cols))
 n_sparray = NamedArray(SparseArrays.sprand(Int, 5, 5, 0.5))
 @test isa(n_sparray.array, SparseMatrixCSC{Int,Int})
 @test isa(convert(NamedArray{Float64}, n_sparray).array, SparseMatrixCSC{Float64,Int})
+
+using DataFrames
+
+@testset "DataFrame <-> NamedArray" begin
+	# Test conversions to and from DataFrame.
+	cn = convert(DataFrame,n)
+	ccn = convert(NamedArray,cn)
+	@test cn isa DataFrame
+	@test ccn isa NamedArray
+	@test ccn == n
+end


### PR DESCRIPTION
This includes a dependency on DataFrame of course. Example usage below.

```julia
using Test, DataFrames
include("test/init-namedarrays.jl")
julia> n
2×4 Named Array{Float64,2}
A ╲ B │         a          b          c          d
──────┼───────────────────────────────────────────
one   │  0.018457  0.0866435   0.738128  0.0961264
two   │  0.458486   0.629748   0.380246   0.785477

julia> cn = convert(NamedArray,n)
2×4 Named Array{Float64,2}
A ╲ B │         a          b          c          d
──────┼───────────────────────────────────────────
one   │  0.018457  0.0866435   0.738128  0.0961264
two   │  0.458486   0.629748   0.380246   0.785477

julia> ccn = convert(NamedArray,cn)
2×4 Named Array{Float64,2}
A ╲ B │         a          b          c          d
──────┼───────────────────────────────────────────
one   │  0.018457  0.0866435   0.738128  0.0961264
two   │  0.458486   0.629748   0.380246   0.785477

@test n == ccn
```