### PR TITLE
Indexing with Not(i::AbstractVector{Bool}) gives the incorrect result

### DIFF
--- a/src/index.jl
+++ b/src/index.jl
@@ -92,6 +92,7 @@ indices(dict::AbstractDict{K,V}, ::Colon) where {K,V<:Integer} = collect(1:lengt
 ## negation
 indices(dict::AbstractDict{K,V}, i::K) where {K<:Not,V<:Integer} = dict[i]
 indices(dict::AbstractDict, i::Not) = setdiff(1:length(dict), indices(dict, i.skip))
+indices(dict::AbstractDict, i::Not{T} where {T <: AbstractVector{Bool}}) = indices(dict, .!i.skip)
 
 ## namedgetindex collects the elements from the array, and takes care of the index names
 ## `index` is an integer now, or an array of integers, or a cartesianindex


### PR DESCRIPTION
closes #101 