### PR TITLE
Fix empty array `show`

### DIFF
--- a/src/show.jl
+++ b/src/show.jl
@@ -67,13 +67,11 @@ end
 function show(io::IO, v::NamedVector)
     println(io, summary(v))
     limit = get(io, :limit, false)
-    if size(v) != (0,)
-        if limit
-            maxnrow = displaysize(io)[1] - 7
-            show(io, v, min(maxnrow, length(v)))
-        else
-            show(io, v, length(v))
-        end
+    if limit
+        maxnrow = displaysize(io)[1] - 7
+        show(io, v, min(maxnrow, length(v)))
+    else
+        show(io, v, length(v))
     end
 end
 
@@ -110,8 +108,8 @@ function show(io::IO, n::NamedMatrix, maxnrow::Int)
     s = [sprint(show, n.array[i,j], context=:compact => true) for i=totrowrange, j=1:ncol]
     rowname, colname = strnames(n)
     strlen(x) = length(string(x))
-    colwidth = max(maximum(map(length, s)), maximum(map(strlen, colname)))
-    rownamewidth = max(maximum(map(strlen, rowname)), sum(map(length, strdimnames(n)))+3)
+    colwidth = max(maximum(map(length, s); init=0), maximum(map(strlen, colname); init=0))
+    rownamewidth = max(maximum(map(strlen, rowname); init=0), sum(map(length, strdimnames(n)))+3)
     if limit
         maxncol = div(displaysize(io)[2] - rownamewidth - 4, colwidth+2) # dots, spaces between
     else
@@ -200,8 +198,8 @@ function show(io::IO, v::NamedVector, maxnrow::Int)
     rownames = strnames(v,1)
     rowrange, totrowrange = compute_range(maxnrow, nrow)
     s = [sprint(show, v.array[i], context=:compact => true) for i=totrowrange]
-    colwidth = maximum(map(length,s))
-    rownamewidth = max(maximum(map(length, rownames)), 1+length(strdimnames(v)[1]))
+    colwidth = maximum(map(length,s); init = 0)
+    rownamewidth = max(maximum(map(length, rownames); init = 0), 1+length(strdimnames(v)[1]))
     ## header
     println(io, string(leftalign(strdimnames(v, 1), rownamewidth), " │ "))
     print(io, "─"^(rownamewidth+1), "┼", "─"^(colwidth+1))

--- a/test/show.jl
+++ b/test/show.jl
@@ -30,11 +30,26 @@ else
 end
 
 lines = showlines(NamedArray([]))
-@test length(lines) == 2
+@test length(lines) == 3
 if VERSION >= v"1.6.0"
     @test lines[1] == "0-element Named Vector{Any}"
 else
     @test lines[1] == "0-element Named Array{Any,1}"
+end
+@test split(lines[2]) == ["A", "│"]
+
+for k in 0:5, (m,n) in ((k,0), (0,k))
+    local lines = showlines(NamedArray(Matrix{Int}(undef, m, n)))
+    @test length(lines) == 3 + m
+    if VERSION >= v"1.6.0"
+        @test lines[1] == "$m×$n Named Matrix{Int64}"
+    else
+        @test lines[1] == "$m×$n Named Array{Int64,2}"
+    end
+    @test split(lines[2]) == [["A", "╲", "B", "│"]; string.(1:n)]
+    for i in 1:m
+        @test split(lines[3+i])[1] == string(i)
+    end
 end
 
 for _lines in Any[showlines(n), showlines(MIME"text/plain"(), n)]


### PR DESCRIPTION
```
emptyvec = NamedArray(Int[], [], "x");
emptymat = NamedArray(Matrix{Int}(undef,0,0), ([],[]), ("x","y"));
```

Before:
```
julia> emptyvec
0-element Named Vector{Int64}


julia> emptymat
0×0 Named Matrix{Int64}
Error showing value of type NamedMatrix{Int64, Matrix{Int64}, Tuple{OrderedCollections.OrderedDict{Any, Int64}, OrderedCollections.OrderedDict{Any, Int64}}}:
ERROR: ArgumentError: reducing over an empty collection is not allowed
[...]
```
After:
```
julia> emptyvec
0-element Named Vector{Int64}
x  │
───┼─

julia> emptymat
0×0 Named Matrix{Int64}
x ╲ y │
──────┼─
```