### PR TITLE
Add constructor to support named arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,9 @@ n = NamedArray([1 3; 2 4], ( ["a", "b"], ["c", "d"] ), ("Rows", "Cols"))
 # NamedArray{T,N}(a::AbstractArray{T,N}, names::NTuple{N,Vector})
 n = NamedArray([1 3; 2 4], ( ["a", "b"], ["c", "d"] ))
 n = NamedArray([1, 2], ( ["a", "b"], ))  # note the comma after ["a", "b"] to ensure evaluation as tuple
+
+# Names can also be set with keyword arguments
+n = NamedArray([1 3; 2 4]; names=( ["a", "b"], ["c", "d"] ), dimnames=("Rows", "Cols"))
 ```
 This is a more friendly version of the basic constructor, where the range of the dictionaries is automatically assigned the values `1:size(a, dim)` for the `names` in order. If `dimnames` is not specified, the default values will be used (`:A`, `:B`, etc.).
 

--- a/src/constructors.jl
+++ b/src/constructors.jl
@@ -44,6 +44,7 @@ end
 ## constructor with array, names and dimnames (dict is created from names)
 """
     NamedArray(a::AbstractArray{T,N}, names::Tuple{N,AbstractVector}, dimnames::NTuple{N,Any}))
+    NamedArray(a::AbstractArray{T,N}; names::Tuple{N,AbstractVector}, dimnames::NTuple{N,Any}))
 
 Construct a NamedArray from array `a`, with names for the indices in each dimesion `names`, 
 and names of the dimensions `dimnames`. 
@@ -60,6 +61,22 @@ A ╲ B │ 1  2  3
 1     │ 1  2  3
 2     │ 4  5  6
 
+
+julia> NamedArray([1 2 3; 4 5 6]; names=(["a", "b"], 1:3))
+2×3 Named Matrix{Int64}
+A ╲ B │ 1  2  3
+──────┼────────
+a     │ 1  2  3
+b     │ 4  5  6
+
+
+julia> NamedArray([1 2 3; 4 5 6]; dimnames=("rows", "cols"))
+2×3 Named Matrix{Int64}
+rows ╲ cols │ 1  2  3
+────────────┼────────
+1           │ 1  2  3
+2           │ 4  5  6
+
 julia> NamedArray([1 2; 3 4; 5 6], (["一", "二", "三"], ["first", "second"]), ("cmn", "en"))
 3×2 Named Matrix{Int64}
 cmn ╲ en │  first  second
@@ -70,8 +87,13 @@ cmn ╲ en │  first  second
 ```
 """
 function NamedArray(array::AbstractArray{T,N},
-                    names::NTuple{N,AbstractVector}=tuple((defaultnames(d) for d in size(array))...),
+                    names::NTuple{N,AbstractVector},
                     dimnames::NTuple{N, Any}=defaultdimnames(array)) where {T,N}
+    NamedArray(array; names, dimnames)
+end
+function NamedArray(array::AbstractArray{T,N};
+                    names::NTuple{N,AbstractVector}=tuple((defaultnames(d) for d in size(array))...),
+                    dimnames::NTuple{N,Any}=defaultdimnames(array)) where {T,N}
     dicts = defaultnamesdict(names)
     NamedArray{T, N, typeof(array), typeof(dicts)}(array, dicts, dimnames)
 end

--- a/test/constructors.jl
+++ b/test/constructors.jl
@@ -30,6 +30,20 @@ n = @inferred NamedArray(rand(2,4))
 @inferred setnames!(n, ["one", "two"], 1)
 @inferred setnames!(n, ["a", "b", "c", "d"], 2)
 
+# keyword constructors
+n8 = NamedArray(rand(2,2,2); names=( ["a", "b"], ["c", "d"], 1:2), dimnames=("Rows", "Cols", "Z"))
+@test names(n8, 1) == ["a", "b"]
+@test names(n8, 3) == [1, 2]
+
+n9 = NamedArray(rand(2,2,2); dimnames=("Rows", "Cols", "Z"))
+@test dimnames(n9) == ["Rows", "Cols", "Z"]
+
+n10 = NamedArray(rand(2,2,2); names=(["a", "b"], ["c", "d"], 1:2))
+@test names(n10, 1) == ["a", "b"]
+@test names(n10, 2) == ["c", "d"]
+@test names(n10, 3) == [1, 2]
+@test dimnames(n10) == [:A, :B, :C]
+
 a = [1 2 3; 4 5 6]
 n3 = @inferred NamedArray(a, (["a","b"],["C","D","E"]))
 n4 = @inferred NamedArray(a, (OrderedDict("a"=>1,"b"=>2), OrderedDict("C"=>1,"D"=>2,"E"=>3)))


### PR DESCRIPTION
This PR adds a convenient way to create NamedArrays setting just the dimension names, the row/column names, or both, using named arguments.

All previous behaviour should remain unchanged.

```julia
julia> NamedArray([1 2 3; 4 5 6]; names=(["a", "b"], 1:3))
2×3 Named Matrix{Int64}
A ╲ B │ 1  2  3
──────┼────────
a     │ 1  2  3
b     │ 4  5  6


julia> NamedArray([1 2 3; 4 5 6]; dimnames=("rows", "cols"))
2×3 Named Matrix{Int64}
rows ╲ cols │ 1  2  3
────────────┼────────
1           │ 1  2  3
2           │ 4  5  6
```

Previously, the most direct approach to setting just the dimnames was to call the modifier afterwards
```julia
julia> a = NamedArray(rand(10,10));
julia> setdimnames!(a, [:dim1, :dim2]);
```

See discussion: https://discourse.julialang.org/t/namedarray-specifying-only-dimension-names/77895

FYI, there was a failing test (unrelated to the changes here) which I had to comment out to get tests passing. Not sure what the failing test was for.

```julia-repl
arithmetic, ┌ Warning: Dropping mismatching names
└ @ NamedArrays C:\projects\NamedArrays.jl\src\arithmetic.jl:27
┌ Warning: Dropping mismatching names
      @ Base.MainInclude .\client.jl:476
    [6] top-level scope
      @ C:\projects\NamedArrays.jl\test\runtests.jl:21
    [7] include(fname::String)
      @ Base.MainInclude .\client.jl:476
    [8] top-level scope
      @ none:6
    [9] eval
      @ .\boot.jl:368 [inlined]
   [10] exec_options(opts::Base.JLOptions)
      @ Base .\client.jl:276
   [11] _start()
      @ Base .\client.jl:522
ERROR: LoadError: There was an error during testing
in expression starting at C:\projects\NamedArrays.jl\test\arithmetic.jl:152
in expression starting at C:\projects\NamedArrays.jl\test\test.jl:21
in expression starting at C:\projects\NamedArrays.jl\test\runtests.jl:21
ERROR: Package NamedArrays errored during testing
```