### PR TITLE
Support use of colon in selectors

### DIFF
--- a/src/index.jl
+++ b/src/index.jl
@@ -150,6 +150,9 @@ function indices(n::NamedArray, I::Pair...)
     fill!(result, :) ## unspecified dimensions act as colon
     for (i, dim) in enumerate(n.dimnames)
         if dim in keys(dict)
+            if dict[dim] isa Colon
+                continue
+            end
             result[i] = n.dicts[i][dict[dim]]
         end
     end


### PR DESCRIPTION
Minor change to allow use of colons in dimension selection.

This is useful if the selections are being generated and not known ahead of time.

```julia
julia> d = NamedArray(rand(3,3,3), (1:3, ["a", "b", "c"], 1:3), (:t, :v, :e))
3×3×3 Named Array{Float64, 3}

[:, :, e=1] =
t ╲ v │        a         b         c
──────┼─────────────────────────────
1     │ 0.324683  0.161698  0.813854
2     │  0.28607  0.977829  0.801814
3     │ 0.823698  0.035209  0.524037

[:, :, e=2] =
t ╲ v │         a          b          c
──────┼────────────────────────────────
1     │  0.343956   0.576392   0.665359
2     │  0.312337   0.195343    0.56295
3     │ 0.0345126   0.683974   0.436669

[:, :, e=3] =
t ╲ v │         a          b          c
──────┼────────────────────────────────
1     │  0.164156   0.762873   0.162808
2     │  0.858393   0.222447   0.276161
3     │  0.325861  0.0688061   0.499486

julia> d[:t=>1]
3×3 Matrix{Float64}:
 0.324683  0.343956  0.164156
 0.161698  0.576392  0.762873
 0.813854  0.665359  0.162808

julia> d[:t=>1, :v=>:, :e=>1]
3-element Vector{Float64}:
 0.324682909881735
 0.1616978784115306
 0.8138541919119265
```

Further work is required to support ranges, e.g:

```julia
d[:t=>1:3]
```
