### PR TITLE
Named range indices

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,8 +191,17 @@ You can also use a dictionary-style indexing, if you don't want to bother about 
 ```julia
 n[:A => "one"] == [1, 2, 3]
 n[:B => :c, :A => "two"] == 6
+n[:A=>:, :B=>:c] == [3, 6]
+
+n[:B=>[:a, :b]] == [1 2; 4 5]
+n[:A=>["one", "two"], :B=>:a] == [1, 4]
+n[:A=>[1, 2], :B=>:a] == [1, 4]
+n[:A=>["one"], :B=>1:2] == [1 2]
+
+# Throws ArgumentError when trying to access non-existant dimension.
+n[:A=>["three"]]
+# ERROR: ArgumentError: Elements for A => ["three"] not found.
 ```
-This style cannot be mixed with other indexing styles, yet.
 
 ### Assignment
 

--- a/src/arithmetic.jl
+++ b/src/arithmetic.jl
@@ -194,14 +194,14 @@ end
 
 ## from factorization
 function qr!(n::NamedMatrix, ::Val{false}; kwargs...)
-    qr = qr!(n.array, Val(false), kwargs...)
+    qr = qr!(n.array, NoPivot(), kwargs...)
     LinearAlgebra.QRCompactWY(NamedArray(qr.factors, n.dicts, n.dimnames), qr.T)
 end
-qr!(n::NamedArray; kwargs...) = qr!(n, Val(false), kwargs...)
+qr!(n::NamedArray; kwargs...) = qr!(n, NoPivot(), kwargs...)
 
 LAPACK.gemqrt!(side::Char, trans::Char, V::NamedArray{BF}, T::StridedMatrix{BF}, C::StridedVecOrMat{BF}) where {BF<:LinearAlgebra.BlasFloat} = LAPACK.gemqrt!(side, trans, V.array, T, C)
 
-qr(n::NamedMatrix{T}, ::Val{false}) where {T<:LinearAlgebra.BlasFloat} = qr!(copy(n), Val(false))
+qr(n::NamedMatrix{T}, ::Val{false}) where {T<:LinearAlgebra.BlasFloat} = qr!(copy(n), NoPivot())
 
 eigen!(n::NamedMatrix; permute::Bool=true, scale::Bool=true) = eigen!(n.array, permute=permute, scale=scale)
 eigen(n::NamedMatrix; permute::Bool=true, scale::Bool=true) = eigen!(copy(n.array), permute=permute, scale=scale)

--- a/src/index.jl
+++ b/src/index.jl
@@ -146,11 +146,15 @@ end
 function indices(n::NamedArray, I::Pair...)
     dict = Dict(I...)
     Set(keys(dict)) ⊆ Set(n.dimnames) || error("Dimension name mismatch")
-    result = Vector{Union{Int,Colon}}(undef, ndims(n))
+    result = Vector{Union{Int,Colon,AbstractRange}}(undef, ndims(n))
     fill!(result, :) ## unspecified dimensions act as colon
     for (i, dim) in enumerate(n.dimnames)
         if dim in keys(dict)
             if dict[dim] isa Colon
+                continue
+            end
+            if dict[dim] isa AbstractRange
+                result[i] = dict[dim]
                 continue
             end
             result[i] = n.dicts[i][dict[dim]]

--- a/test/index.jl
+++ b/test/index.jl
@@ -82,3 +82,10 @@ m[[1,9,10]] = 0:2
 
 n[1,1] = π
 @test n.array[1,1] == Float64(π)
+
+m = NamedArray(rand(10,2), dimnames=(:rows, :cols))
+@test m[:rows=>1:5, :cols=>:] == m[1:5, :]
+@test m[:rows=>3:end, :cols=>:] == m[3:end, :]
+@test m[:rows=>1:2:8, :cols=>:] == m[1:2:8, :]
+@test m[:rows=>:, :cols=>"1"] == m[:, 1]
+@test m[:rows=>"1", :cols=>:] == m[1, :]

--- a/test/index.jl
+++ b/test/index.jl
@@ -89,3 +89,4 @@ m = NamedArray(rand(10,2), dimnames=(:rows, :cols))
 @test m[:rows=>1:2:8, :cols=>:] == m[1:2:8, :]
 @test m[:rows=>:, :cols=>"1"] == m[:, 1]
 @test m[:rows=>"1", :cols=>:] == m[1, :]
+@test m[:rows=>[1,2,3], :cols=>:] == m[[1,2,3], :]


### PR DESCRIPTION
Add support for ranged indices, vectors of names or vectors of positional selectors.

```julia
n = NamedArray([1 2 3; 4 5 6], (["one", "two"], [:a, :b, :c]))
n[:B=>[:a, :b]] == [1 2; 4 5]
n[:A=>["one", "two"], :B=>:a] == [1, 4]
n[:A=>[1, 2], :B=>:a] == [1, 4]
n[:A=>["one"], :B=>1:2] == [1 2]

# Throws ArgumentError when trying to access non-existant dimension.
n[:A=>["three"]]
# ERROR: ArgumentError: Elements for A => ["three"] not found.
```

Also included is a small change to address a deprecation warning from `qr()`