### PR TITLE
Use print instead of show when constructing names for display

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -23,8 +23,9 @@ Requires = "1"
 julia = "1"
 
 [extras]
+InlineStrings = "842dd82b-1e85-43dc-bf29-5d0ee9dffc48"
 KahanSummation = "8e2b3108-d4c1-50be-a7a2-16352aec75c3"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["KahanSummation", "Test"]
+test = ["InlineStrings", "KahanSummation", "Test"]

--- a/src/names.jl
+++ b/src/names.jl
@@ -65,7 +65,7 @@ dimnames(a::AbstractArray) = [defaultdimnames(a)...]
 dimnames(a::AbstractArray, d::Integer) = defaultdimname(d)
 
 ## string versions of the above
-strnames(dict::AbstractDict) = [isa(name, String) ? name : sprint(show, name, context=:compact => true) for name in names(dict)]
+strnames(dict::AbstractDict) = [sprint(print, name, context=:compact => true) for name in names(dict)]
 strnames(n::NamedArray) = [strnames(d) for d in n.dicts]
 strnames(n::NamedArray, d::Integer) = strnames(n.dicts[d])
 strdimnames(n::NamedArray) = [string(dn) for dn in n.dimnames]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -15,6 +15,7 @@ using SparseArrays
 using DelimitedFiles
 using Statistics
 using Random
+using InlineStrings
 
 using KahanSummation
 


### PR DESCRIPTION
Also, change most show methods to be defined for MIME"text/plain" and fallback on based printing for two-argument show.

Fixes #123 