### PR TITLE
It fixes issue #127

### DIFF
--- a/src/constructors.jl
+++ b/src/constructors.jl
@@ -89,7 +89,7 @@ cmn ╲ en │  first  second
 function NamedArray(array::AbstractArray{T,N},
                     names::NTuple{N,AbstractVector},
                     dimnames::NTuple{N, Any}=defaultdimnames(array)) where {T,N}
-    NamedArray(array; names, dimnames)
+    NamedArray(array; names=names, dimnames=dimnames)
 end
 function NamedArray(array::AbstractArray{T,N};
                     names::NTuple{N,AbstractVector}=tuple((defaultnames(d) for d in size(array))...),


### PR DESCRIPTION
This pull request addresses an issue with the keyword argument syntax in the `NamedArray` function definitions. The existing syntax, which uses the shorthand `NamedArray(array; names, dimnames)`, is not supported in Julia 1.0 and therefore causes compatibility issues. 

In this PR, I have updated the syntax to `NamedArray(array; names=names, dimnames=dimnames)`, which is supported across all Julia 1.x versions. This update should improve the backward compatibility of the package without affecting its functionality in newer Julia versions.