### PR TITLE
Axis array constructor

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -25,7 +25,8 @@ julia = "1"
 [extras]
 InlineStrings = "842dd82b-1e85-43dc-bf29-5d0ee9dffc48"
 KahanSummation = "8e2b3108-d4c1-50be-a7a2-16352aec75c3"
+AxisArrays = "39de3d68-74b9-583c-8d2d-e117c070f3a9"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["InlineStrings", "KahanSummation", "Test"]
+test = ["InlineStrings", "KahanSummation", "AxisArrays", "Test"]

--- a/src/NamedArrays.jl
+++ b/src/NamedArrays.jl
@@ -48,6 +48,17 @@ function __init__()
             NamedArrays.fan(KahanSummation.cumsum_kbn, "cumsum_kbn", a; dims=dims)
         end
     end
+
+    @require AxisArrays="39de3d68-74b9-583c-8d2d-e117c070f3a9" begin
+
+        ## constructor for AxisArray
+        function NamedArray(axisarray::AxisArrays.AxisArray{T, N, D, Ax}) where {T, N, D, Ax}
+            axes = AxisArrays.axes(axisarray)
+            dimlabels = ntuple(i -> first(AxisArrays.axisvalues(axes[i])), N)
+            dimnames = ntuple(i -> first(AxisArrays.axisnames(axes[i])), N)
+            return NamedArray(axisarray.data; names=dimlabels, dimnames=dimnames)
+        end
+    end
 end
 
 end

--- a/test/constructors.jl
+++ b/test/constructors.jl
@@ -87,4 +87,18 @@ using Test
     @testset "Simplify vector constructor, #86" begin
         n8 = @inferred NamedArray([1, 2, 3], ["a", "b", "c"])
     end
+
+    @testset "Construction from AxisArray, #142" begin
+        axisarray = AxisArray(
+            rand(2,3,4),
+            Axis{:dim1}([:A, :B]),
+            Axis{:dim2}([:X, :Y, :Z]),
+            Axis{:dim3}([:F, :G, :H, :I]))
+
+        n11 = NamedArray(axisarray)
+        @test n11 isa NamedArray
+        @test dimnames(n11) == [:dim1, :dim2, :dim3]
+        @test names(n11) == [[:A, :B], [:X, :Y, :Z], [:F, :G, :H, :I]]
+        @test all(n11 .== axisarray)
+    end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -18,5 +18,6 @@ using Random
 using InlineStrings
 
 using KahanSummation
+using AxisArrays
 
 include("test.jl")


### PR DESCRIPTION
Adds a constructor for NamedArrays from AxisArray objects, addressing #142 . The `AxisArray` type is loaded with `@require` to avoid adding a dependency. Do let me know if anything could be improved!